### PR TITLE
fix: work around Bun's c-ares DNS falling back to a dead 127.0.0.1 (intermittent "checking connectivity" / ETIMEOUT)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,7 @@ If you haven't installed yet, see [install.md](install.md) first.
 ## Table of Contents
 
 - [Claude crashes immediately on launch](#claude-crashes-immediately-on-launch)
+- [Claude hangs on "Checking connectivity" / ETIMEOUT / 'API error' on every message](#claude-hangs-on-checking-connectivity--etimeout--api-error-on-every-message)
 - [Unsupported architecture: armhf](#unsupported-architecture-armhf)
 - [Claude Code won't start, no error](#claude-code-wont-start-no-error-v2x-install)
 - [Claude Code exits: "native binary not installed"](#claude-code-exits-native-binary-not-installed-historical--v2x-context)
@@ -74,6 +75,34 @@ The pinned version is a safety net, not a one-way street: once a working Claude 
 Running Claude Code inside proot-distro Ubuntu (Path B) is another way around it; see the [install guide](install.md).
 
 **Why it happens, briefly:** Android runs every app under a filter that permits only a fixed set of low-level system calls. A native program like Claude Code sometimes uses a newer system call the filter was not told to allow, and Android stops the program instead of letting the call through. `claude --version` survives because it quits before it reaches that point; a real launch does not. The launcher in v2.9.2 and later tests each version this way and rolls back when one fails. One instance, on newer phones, is in the Bun runtime Claude Code is built on, tracked upstream at oven-sh/bun#32489.
+
+---
+
+### Claude hangs on "Checking connectivity" / ETIMEOUT / 'API error' on every message
+
+**You see:** Claude starts, then hangs on `Checking connectivity...` and fails with:
+
+```
+Unable to connect to Anthropic services
+Failed to connect to api.anthropic.com: ETIMEOUT
+```
+
+even though `curl https://api.anthropic.com/` connects fine over both IPv4 and IPv6. It is often **intermittent** - fine one launch, hung the next - and is unrelated to your Claude Code version or to running as root. (On an already-logged-in session it may instead surface as an API error when you send a message.)
+
+**Fix:** Update to the latest `install.sh` (or just re-run if using the curl + bash command). The launcher now points Claude Code's DNS resolver at a working nameserver automatically: it writes a tiny `setdns.js` next to the binary and loads it with `BUN_OPTIONS=--preload` on every launch (no binary patching, no extra permissions, no daemon). To confirm it's in place:
+
+```bash
+cat ~/.local/share/claude/setdns.js   # -> require("dns").setServers(["8.8.8.8", ...])
+```
+
+If you'd rather fix it by hand without re-running the installer, set it in the shell that launches claude:
+
+```bash
+echo 'try { require("dns").setServers(["8.8.8.8","8.8.4.4"]); } catch(e){}' > ~/setdns.js
+export BUN_OPTIONS="--preload $HOME/setdns.js"
+```
+
+**Why it happens, briefly:** Claude Code is built with Bun, whose DNS resolver (c-ares) reads `/etc/resolv.conf` to find a nameserver. On Android `/etc` is a read-only link to `/system/etc` with no `resolv.conf`, so c-ares falls back to its built-in default `127.0.0.1:53` — where nothing is listening. The glibc resolver Termux ships *does* work (it reads `$PREFIX/glibc/etc/resolv.conf`), but Bun uses both, and under the burst of name lookups at startup the dead-loopback queries time out and starve the working path. `curl` is unaffected because it uses Android's own (bionic/netd) resolver. The preload calls `dns.setServers()` to hand c-ares a live nameserver before the first lookup, so it never hits the dead loopback.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,14 @@ ok(){   printf '\033[0;32m[ok]\033[0m    %s\n' "$1"; }
 warn(){ printf '\033[0;33m[warn]\033[0m  %s\n' "$1" >&2; }
 fail(){ printf '\033[0;31m[fail]\033[0m  %s\n' "$1" >&2; exit 1; }
 
+# DNS ETIMEOUT fix: preload sets Bun's c-ares resolver to a live nameserver (the wrapper loads it via BUN_OPTIONS).
+CC_SETDNS="$HOME/.local/share/claude/setdns.js"
+CC_SETDNS_JS='try { require("dns").setServers(["8.8.8.8", "8.8.4.4"]); } catch (e) {}'
+write_setdns() {
+  [ -s "$1" ] && return 0
+  printf '%s\n' "$CC_SETDNS_JS" > "$1" 2>/dev/null
+}
+
 # --- Preflight ---
 [ -z "${PREFIX:-}" ] && fail "PREFIX unset. Run this inside Termux, not adb shell."
 [ "$(uname -m)" = "aarch64" ] || fail "aarch64 only. uname -m reports: $(uname -m)"
@@ -275,6 +283,10 @@ LD_PRELOAD='' "$PATCHELF" --set-interpreter "$GLIBC_LD" "$BINARY.tmp" \
 mv "$BINARY.tmp" "$BINARY"
 ok "binary patched and installed at $BINARY"
 
+write_setdns "$CC_SETDNS"
+[ -s "$CC_SETDNS" ] && ok "DNS resolver preload installed ($CC_SETDNS)" \
+  || warn "could not write $CC_SETDNS; DNS ETIMEOUT workaround inactive."
+
 # Smoke-test the freshly installed binary. Some upstream releases crash on full
 # launch under Android's seccomp filter while still passing "--version" (Android
 # 10 statx -> SIGSYS; Bun 1.4 epoll_pwait2 -> SIGSEGV). Probe with --init-only
@@ -354,6 +366,13 @@ STAMP="\$VERSIONS_DIR/.last-update-check"
 BLOCKLIST="\$VERSIONS_DIR/.blocklist"
 VERIFIED="\$VERSIONS_DIR/.verified"
 RATE_LIMIT=86400
+
+CC_SETDNS="$HOME/.local/share/claude/setdns.js"
+CC_SETDNS_JS='try { require("dns").setServers(["8.8.8.8", "8.8.4.4"]); } catch (e) {}'
+write_setdns() {
+  [ -s "\$1" ] && return 0
+  printf '%s\n' "\$CC_SETDNS_JS" > "\$1" 2>/dev/null
+}
 
 # Smoke test: returns 0 if the binary launches on this device, 1 if it crashes
 # or hangs. Why this exists: upstream has shipped binaries that pass "--version"
@@ -480,6 +499,8 @@ if [ -z "\$bin" ]; then
   exit 1
 fi
 
+write_setdns "\$CC_SETDNS"
+[ -f "\$CC_SETDNS" ] && export BUN_OPTIONS="--preload \$CC_SETDNS\${BUN_OPTIONS:+ \$BUN_OPTIONS}"
 unset LD_PRELOAD
 exec "\$bin" "\${args[@]}"
 EOF

--- a/migrate.sh
+++ b/migrate.sh
@@ -33,6 +33,14 @@ ok(){   printf '\033[0;32m[ok]\033[0m    %s\n' "$1"; }
 warn(){ printf '\033[0;33m[warn]\033[0m  %s\n' "$1" >&2; }
 fail(){ printf '\033[0;31m[fail]\033[0m  %s\n' "$1" >&2; exit 1; }
 
+# DNS ETIMEOUT fix: preload sets Bun's c-ares resolver to a live nameserver (the wrapper loads it via BUN_OPTIONS).
+CC_SETDNS="$HOME/.local/share/claude/setdns.js"
+CC_SETDNS_JS='try { require("dns").setServers(["8.8.8.8", "8.8.4.4"]); } catch (e) {}'
+write_setdns() {
+  [ -s "$1" ] && return 0
+  printf '%s\n' "$CC_SETDNS_JS" > "$1" 2>/dev/null
+}
+
 BACKUP_DIR=""
 on_err(){
   ec=$?
@@ -280,6 +288,10 @@ LD_PRELOAD='' "$PATCHELF" --set-interpreter "$GLIBC_LD" "$BINARY.tmp" \
 mv "$BINARY.tmp" "$BINARY"
 ok "new binary staged at $BINARY"
 
+write_setdns "$CC_SETDNS"
+[ -s "$CC_SETDNS" ] && ok "DNS resolver preload installed ($CC_SETDNS)" \
+  || warn "could not write $CC_SETDNS; DNS ETIMEOUT workaround inactive."
+
 # Smoke-test the new binary BEFORE removing the working install. If the latest
 # Claude Code crashes on this device (a known upstream regression under Android's
 # seccomp filter: Android 10 statx, or Bun 1.4 epoll_pwait2), abort and leave the
@@ -338,6 +350,13 @@ STAMP="\$VERSIONS_DIR/.last-update-check"
 BLOCKLIST="\$VERSIONS_DIR/.blocklist"
 VERIFIED="\$VERSIONS_DIR/.verified"
 RATE_LIMIT=86400
+
+CC_SETDNS="$HOME/.local/share/claude/setdns.js"
+CC_SETDNS_JS='try { require("dns").setServers(["8.8.8.8", "8.8.4.4"]); } catch (e) {}'
+write_setdns() {
+  [ -s "\$1" ] && return 0
+  printf '%s\n' "\$CC_SETDNS_JS" > "\$1" 2>/dev/null
+}
 
 # Smoke test: returns 0 if the binary launches on this device, 1 if it crashes
 # or hangs. Why this exists: upstream has shipped binaries that pass "--version"
@@ -464,6 +483,8 @@ if [ -z "\$bin" ]; then
   exit 1
 fi
 
+write_setdns "\$CC_SETDNS"
+[ -f "\$CC_SETDNS" ] && export BUN_OPTIONS="--preload \$CC_SETDNS\${BUN_OPTIONS:+ \$BUN_OPTIONS}"
 unset LD_PRELOAD
 exec "\$bin" "\${args[@]}"
 EOF


### PR DESCRIPTION
## What this fixes

The intermittent `Failed to connect to api.anthropic.com: ETIMEOUT` / hang on **"Checking connectivity…"** on the native Termux path, occurs even when `curl https://api.anthropic.com/` works over both IPv4 and IPv6. On an already-logged-in session it can instead show up as an API error on the first message. It's intermittent (fine one launch, hung the next) and is **not** tied to a Claude Code version or to running as root.

Addresses #7

## Root cause

Claude Code is a Bun binary, and **Bun's `fetch` resolves DNS through c-ares** (not libc `getaddrinfo` like Node's `dns.lookup`). c-ares reads **`/etc/resolv.conf`** to find a nameserver. On Android `/etc` is a read-only symlink to `/system/etc` and has **no `resolv.conf`**, so c-ares falls back to its built-in default **`127.0.0.1:53`** — where nothing is listening.

glibc's `getaddrinfo` *does* work here (it reads `$PREFIX/glibc/etc/resolv.conf` → `8.8.8.8`), and Bun uses **both** resolvers. Under the burst of concurrent name lookups at startup (`api.anthropic.com`, `platform.claude.com`, `statsig…`, `raw.githubusercontent.com`), the dead-loopback c-ares queries time out and **starve out** the working glibc path → `ETIMEOUT`. `curl` is unaffected because it uses Android's own bionic/`netd` resolver. That's why it looks version/uid-correlated but isn't.

### Evidence (strace, native Termux, Pixel 10 Pro Fold / Android 16)

```
openat("/etc/resolv.conf", O_RDONLY)               = -1 ENOENT   # c-ares config: missing
sendto(fd, <query api.anthropic.com>, ... 127.0.0.1:53)          # ... so it queries the dead loopback
recvfrom(fd, ...)                                  = -1 EAGAIN   # ...x22, never answered
openat(".../glibc/etc/resolv.conf", O_RDONLY)      = 17          # getaddrinfo path → 8.8.8.8 (works, but starved)
```

## The fix

The compiled binary honors **`BUN_OPTIONS=--preload <file>`**, so the launcher writes a one-line `setdns.js` and preloads it on every launch:

```js
try { require("dns").setServers(["8.8.8.8", "8.8.4.4"]); } catch (e) {}
```

`dns.setServers()` hands c-ares a live nameserver before the first lookup, so it never hits the dead loopback. After this: **0 queries to `127.0.0.1`, all DNS to `8.8.8.8`**, hang gone.

## Changes

- **`install.sh`** — write `~/.local/share/claude/setdns.js` at install, the wrapper exports `BUN_OPTIONS=--preload …` (guarded) before `exec`, and re-ensures the file on every launch.
- **`migrate.sh`** - identical change (kept byte-identical per the SYNC NOTE; wrappers verified identical).
- **`docs/troubleshooting.md`** — new symptom entry + ToC link.

## Upgrade path

Existing v2.9 installs just **re-run `install.sh`** — it refreshes the launcher in place (no 233 MB re-download), and the fix applies on the next launch via the wrapper. New/in-place installs get `setdns.js` written at install time as well.

## Testing

Verified on a Pixel 10 Pro Fold (Android 16, aarch64), Claude Code 2.1.195, **unpatched binary, no forwarder, `127.0.0.1:53` confirmed dead**:

- before: `Checking connectivity… → ETIMEOUT`
- after: reaches the logged-in prompt ("Welcome back"), strace shows **2× `8.8.8.8`, 0× `127.0.0.1`**.

`bash -n` passes on `install.sh`, `migrate.sh`, and both rendered wrappers.

## Notes

- `BUN_OPTIONS` is inherited by any child `bun` processes Claude spawns, they'd just harmlessly re-run `setServers`.
- Relies on Bun honoring `BUN_OPTIONS=--preload` (confirmed on 2.1.195). If a future Bun changes this, the guard makes it a no-op rather than a breakage.
